### PR TITLE
fix(tools): bump github actions to node 24 runtimes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,10 +15,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: '22.x'
+          node-version: '24.x'
 
       - name: Install Dependencies 📌
         run: npm ci --ignore-scripts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           # fetch-depth is necessary to get all tags
           # otherwise lerna can't detect the changes and will end up bumping the versions for all packages
@@ -17,9 +17,9 @@ jobs:
           token: ${{ secrets.RELEASE_COMMIT_GH_PAT }}
           persist-credentials: false
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           always-auth: false # important for trusted publishing
       - name: Configure CI Git User

--- a/.github/workflows/sync-docs.yaml
+++ b/.github/workflows/sync-docs.yaml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout Extension Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           token: ${{env.GITHUB_TOKEN}}
           path: './extension/'
 
       - name: Checkout Docs Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           token: ${{env.GITHUB_TOKEN}}
           repository: ${{env.DOCS_REPO}}


### PR DESCRIPTION
## Description

The workflows in this repo emit a Node.js 20 deprecation warning on every run:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4
```

GitHub has removed Node 20 from its runners and force-runs Node 20 actions on Node 24. Builds still succeed, but the annotation appears on every run and becomes a hard failure once the compatibility shim is dropped.

This moves every affected first-party action onto a major that declares `using: node24`, and raises any `node-version` still below 24.

**Action pins**

| File | Was | Now |
| --- | --- | --- |
| `.github/workflows/main.yaml` | `actions/checkout@v3` | `actions/checkout@v5` |
| `.github/workflows/main.yaml` | `actions/setup-node@v3` | `actions/setup-node@v5` |
| `.github/workflows/release.yaml` | `actions/checkout@v3` | `actions/checkout@v5` |
| `.github/workflows/release.yaml` | `actions/setup-node@v3` | `actions/setup-node@v5` |
| `.github/workflows/sync-docs.yaml` | `actions/checkout@v3` | `actions/checkout@v5` |
| `.github/workflows/sync-docs.yaml` | `actions/checkout@v3` | `actions/checkout@v5` |

**Node versions**

| File | Was | Now |
| --- | --- | --- |
| `.github/workflows/main.yaml` | `'22.x'` | `'24.x'` |
| `.github/workflows/release.yaml` | `'22'` | `'24'` |

Each target major was verified to declare `using: node24` by reading its `action.yml` at the pinned tag.

**Deliberately unchanged**

- Multi-version test matrices that already include Node 24 are left as-is — collapsing them would drop Node 22 coverage rather than fix a deprecation.
- SHA-pinned third-party actions (e.g. `aquasecurity/trivy-action@<sha>`) are untouched; SHA pinning is correct practice and unrelated to the Node runtime.

Fixes #31

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] All changed workflow files validated as parseable YAML
- [x] Each target action major confirmed to declare `using: node24` in its `action.yml`
- [x] Bumps confirmed drop-in for the inputs actually used (no input renames or removals across these majors)
- [x] Local pre-commit hook (test + lint) run as part of committing

Scope of this change: 3 file(s) — 3 files changed, 8 insertions(+), 8 deletions(-). CI configuration only; no application source touched.

The warning can be confirmed gone by running a workflow and checking the run summary's **Annotations** section.

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes — n/a, CI configuration only, no code paths changed
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated — n/a
- [x] Any dependent changes have been merged and published in downstream modules
